### PR TITLE
Fix screenshot

### DIFF
--- a/userbot/plugins/pats.py
+++ b/userbot/plugins/pats.py
@@ -11,7 +11,7 @@ from userbot.plugins.help import add_command_help
 
 @UserBot.on_message(filters.command(["pat", "pats"], ".") & filters.me)
 async def give_pats(bot: UserBot, message: Message):
-    URL = "https://some-random-api.ml/animu/pat"
+    URL = "https://some-random-api.com/animu/pat"
     async with aiohttp.ClientSession() as session:
         async with session.get(URL) as request:
             if request.status == 404:

--- a/userbot/plugins/screenshot.py
+++ b/userbot/plugins/screenshot.py
@@ -14,7 +14,7 @@ from userbot.plugins.help import add_command_help
 async def screenshot(bot: UserBot, message: Message):
     await asyncio.gather(
         message.delete(),
-        bot.send(
+        bot.invoke(
             functions.messages.SendScreenshotNotification(
                 peer=await UserBot.resolve_peer(message.chat.id),
                 reply_to_msg_id=0,


### PR DESCRIPTION
The screenshot plugin had outdated `Client.send` method which was causing it to break. So i updated to the working method of `Client.invoke` as per the [Pyrogram 2.0 Release Docs](https://docs.pyrogram.org/releases/v2.0).